### PR TITLE
Support Goodwe Power Meter (Issue #92)

### DIFF
--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -85,6 +85,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     powerflow = result["powerflow"]
 
                 powerflow["sn"] = result["homKit"]["sn"]
+
+                # Goodwe 'Power Meter' (not HomeKit) doesn't have a sn
+                # Let's put something in, otherwise we can't see the data.
+                if powerflow["sn"] is None:
+                    powerflow["sn"] = "GW-HOMEKIT-NO-SERIAL"
+                
                 #_LOGGER.debug("homeKit sn: %s", result["homKit"]["sn"])
                 # This seems more accurate than the Chart_sum
                 powerflow["all_time_generation"] = result["kpi"]["total_power"]


### PR DESCRIPTION
The Power Meter is like a HomeKit in that it exposes grid power in and out, but unlike a HomeKit it doesn't have a serial number. 

Without these lines the data doesn't get collected property. 

I've been running these lines 'hacked in' for the last 10 months.